### PR TITLE
Fix values being #map'd over but not reassigned

### DIFF
--- a/lib/transbank/sdk/onepay/utils/json_utils.rb
+++ b/lib/transbank/sdk/onepay/utils/json_utils.rb
@@ -32,8 +32,9 @@ module Transbank
                   value = value.to_h if value && value.respond_to?(:to_h) unless value.is_a? Array
                   value = value.to_a if value && value.respond_to?(:to_a) unless value.is_a? Hash
                   if value.is_a? Array
-                    value.map {|x| x.respond_to?(:jsonify) ? JSON.parse(x.jsonify) : x }
+                    value = value.map {|x| x.respond_to?(:jsonify) ? JSON.parse(x.jsonify) : x }
                   end
+
                   value = value.jsonify if value.respond_to? :jsonify
                   resulting_hash[instance_variable] = value
                 end

--- a/lib/transbank/sdk/onepay/utils/net_helper.rb
+++ b/lib/transbank/sdk/onepay/utils/net_helper.rb
@@ -21,7 +21,7 @@ module Transbank
         def keys_to_camel_case(hash)
           hash.reduce({}) do |new_hash, (key, val)|
             if val.is_a? Array
-              val.map {|value| value.is_a?(Hash) ? keys_to_camel_case(value) : value }
+              val = val.map {|value| value.is_a?(Hash) ? keys_to_camel_case(value) : value }
             end
             new_key = snake_to_camel_case(key.to_s)
             new_hash[new_key] = val


### PR DESCRIPTION
- On some cases values being #map'd over were not being reassigned to
the variable, which caused the non side effect producing #map to
actually have no effect, since the new values weren't saved anywhere.
Using #map! wasn't an option because it could modify the original values
that we did not want to change