### PR TITLE
Fix TransactionCreateRequest model, to assign channel properly

### DIFF
--- a/lib/transbank/sdk/onepay/requests/transaction_create_request.rb
+++ b/lib/transbank/sdk/onepay/requests/transaction_create_request.rb
@@ -68,7 +68,7 @@ module Transbank
 
       def channel=(channel)
         raise Errors::TransactionCreateError, 'Channel cannot be null.' if channel.nil?
-        channel
+        @channel = channel
       end
 
       def sign(secret)


### PR DESCRIPTION
This PR fix a bug related to the channel parameter, discovered when I was creating a transaction with MOBILE channel.