### PR TITLE
Upgrade to ruby 2.4.x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
-FROM ruby:2.2-jessie
+FROM ruby:2.4-jessie
 RUN apt-get update && apt-get install
-RUN gem install bundler
 RUN mkdir -p /sdk
 WORKDIR /sdk
 COPY . /sdk

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ build: .built .bundled
 	docker-compose build
 	touch .built
 
-.bundled: Gemfile Gemfile.lock
+.bundled: Gemfile
 	docker-compose run --rm web bundle install
 	touch .bundled
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ La documentación relevante para usar este SDK es:
 ### Test
 Primero y solamente una vez para instalar gemas debes usar el siguiente comando en una terminal.
 ```bash
-docker-compose run web bundle install
+make build
 ```
 
 Para ejecutar los test localmente debes usar el siguiente comando en una terminal.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ SDK Oficial de Transbank
 
 ## Requisitos:
 
-- Ruby 2.2+
+- Ruby 2.4+
 
 # Instalación
 
@@ -66,7 +66,7 @@ La documentación relevante para usar este SDK es:
 ### Test
 Primero y solamente una vez para instalar gemas debes usar el siguiente comando en una terminal.
 ```bash
-make build
+docker-compose run web bundle install
 ```
 
 Para ejecutar los test localmente debes usar el siguiente comando en una terminal.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,6 @@ services:
     - "8000:8000"
 
   bundle_cache:
-    image: ruby:2.2-jessie # Should be the same as the app Dockerfile.dev base image
+    image: ruby:2.4-jessie # Should be the same as the app Dockerfile.dev base image
     volumes:
     - /usr/local/bundle


### PR DESCRIPTION
Ruby `2.2.x` and `2.3.x` have reached their end of life. This upgrades Docker to use an 2.4 ruby image.