### PR TITLE
Add default global values for width height and commerce logo

### DIFF
--- a/lib/transbank/sdk/onepay/base.rb
+++ b/lib/transbank/sdk/onepay/base.rb
@@ -55,6 +55,16 @@ module Transbank
         # @return [String] One of the values from Channel.values
         attr_reader :default_channel
 
+        # The width and height in pixels for the returned QR.
+        # @param [Integer]
+        # @return [Integer]
+        attr_accessor :qr_width_height
+
+        # The url of the commerce logo to be displayed in the Onepay mobile app.
+        # @param [String]
+        # @return [String]
+        attr_accessor :commerce_logo_url
+
         # @return [String] the URL that is used by the current integration type
         def current_integration_type_url
           @integration_types[@integration_type]

--- a/lib/transbank/sdk/onepay/utils/request_builder.rb
+++ b/lib/transbank/sdk/onepay/utils/request_builder.rb
@@ -25,7 +25,7 @@ module Transbank
             channel: channel,
             app_scheme: Base.app_scheme,
             commerce_logo_url: options[:commerce_logo_url],
-            width_height: options[:width_height]
+            width_height: options[:qr_width_height]
           )
           request.set_keys_from_options(options)
           request.app_key = Base::current_integration_type_app_key
@@ -83,8 +83,12 @@ module Transbank
         # shared_secret: Base::shared_secret
         # @return [Hash] a hash with the aforementioned keys/values
         def default_options
-          { api_key: Base::api_key,
-            shared_secret: Base::shared_secret }
+          {
+            api_key: Base::api_key,
+            shared_secret: Base::shared_secret,
+            commerce_logo_url: Base::commerce_logo_url,
+            qr_width_height: Base::qr_width_height
+          }
         end
       end
     end


### PR DESCRIPTION
Default global variables for these two fields were not addded in the original PR,
this fixes their behaviour si it's consistent with the other SDKs