### PR TITLE
Prepare release 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Todos los cambios notables a este proyecto serán documentados en este archivo.
 El formato está basado en [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 y este proyecto adhiere a [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.1.0] - 2018-04-08
+### Added
+- Se agregaron los parámetros `qr_width_height` y `commerce_logo_url` a Options, para especificar el tamaño del QR generado para la transacción, y especificar la ubicación del logo de comercio para ser mostrado en la aplicación móvil de Onepay. Puedes configurar estos parámetros globalmente o por transacción.
+
 ## [1.0.2] - 2018-11-29
 ### Fixed
 - Corrige problema que evitaba poder utilizar un `CHANNEL` distinto a `WEB`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ y este proyecto adhiere a [Semantic Versioning](http://semver.org/spec/v2.0.0.ht
 
 ## [1.1.0] - 2018-04-08
 ### Added
-- Se agregaron los parámetros `qr_width_height` y `commerce_logo_url` a Options, para especificar el tamaño del QR generado para la transacción, y especificar la ubicación del logo de comercio para ser mostrado en la aplicación móvil de Onepay. Puedes configurar estos parámetros globalmente o por transacción.
+- Se agregaron los parámetros `qr_width_height` y `commerce_logo_url` a Options, para definir el tamaño del QR generado para la transacción, y especificar la ubicación del logo de comercio para ser mostrado en la aplicación móvil de Onepay. Puedes configurar estos parámetros globalmente o por transacción.
 
 ## [1.0.2] - 2018-11-29
 ### Fixed

--- a/lib/transbank/sdk/version.rb
+++ b/lib/transbank/sdk/version.rb
@@ -1,5 +1,5 @@
 module Transbank
   module Sdk
-    VERSION = "1.0.2"
+    VERSION = "1.1.0"
   end
 end


### PR DESCRIPTION
You can see the full diff here: [v1.0.2...prepare-release-1.1.0](https://github.com/TransbankDevelopers/transbank-sdk-ruby/compare/v1.0.2...prepare-release-1.1.0)