### PR TITLE
Prepare release 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Todos los cambios notables a este proyecto serán documentados en este archivo.
 El formato está basado en [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 y este proyecto adhiere a [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.2.0] - 2019-12-26
+### Added
+- Se agrega soporte para Oneclick Mall y Transacción Completa en sus versiones REST.
+
 ## [1.1.0] - 2018-04-08
 ### Added
 - Se agregaron los parámetros `qr_width_height` y `commerce_logo_url` a Options, para definir el tamaño del QR generado para la transacción, y especificar la ubicación del logo de comercio para ser mostrado en la aplicación móvil de Onepay. Puedes configurar estos parámetros globalmente o por transacción.

--- a/lib/transbank/sdk/version.rb
+++ b/lib/transbank/sdk/version.rb
@@ -1,5 +1,5 @@
 module Transbank
   module Sdk
-    VERSION = "1.1.0"
+    VERSION = "1.2.0"
   end
 end


### PR DESCRIPTION
You can see the full diff here:[ v1.1.0...prepare-release-1.2.0](https://github.com/TransbankDevelopers/transbank-sdk-ruby/compare/v1.1.0...chore/prepare-release-1.2.0)