### PR TITLE
[Feature] callback_url as option per transaction

### DIFF
--- a/lib/transbank/sdk/utils/request_builder.rb
+++ b/lib/transbank/sdk/utils/request_builder.rb
@@ -21,7 +21,7 @@ module Transbank
             items_quantity: shopping_cart.items_quantity,
             issued_at: issued_at,
             items: shopping_cart.items,
-            callback_url: Base.callback_url,
+            callback_url: options[:callback_url],
             channel: channel,
             app_scheme: Base.app_scheme,
             commerce_logo_url: options[:commerce_logo_url],
@@ -79,15 +79,18 @@ module Transbank
 
         # Return the default options values:
         # api_key: Base::api_key
-        # app_key: Base::current_integration_type_app_key
         # shared_secret: Base::shared_secret
+        # commerce_logo_url: Base::commerce_logo_url
+        # qr_width_height: Base::qr_width_height
+        # callback: Base::callback_url
         # @return [Hash] a hash with the aforementioned keys/values
         def default_options
           {
             api_key: Base::api_key,
             shared_secret: Base::shared_secret,
             commerce_logo_url: Base::commerce_logo_url,
-            qr_width_height: Base::qr_width_height
+            qr_width_height: Base::qr_width_height,
+            callback_url:  Base.callback_url
           }
         end
       end

--- a/test/transbank/onepay/transaction_test.rb
+++ b/test/transbank/onepay/transaction_test.rb
@@ -236,6 +236,22 @@ class TransactionTest < Transbank::Onepay::Test
     Transbank::Onepay::Base.callback_url = original_callback_url
   end
 
+  def test_transaction_succeeds_when_channel_is_mobile_and_callback_url_as_options
+    WebMock.allow_net_connect!
+    original_callback_url = Transbank::Onepay::Base.callback_url
+    Transbank::Onepay::Base.callback_url = nil
+
+    cart = Transbank::Onepay::Mocks::ShoppingCartMocks[0]
+    options = { callback_url: "http://some.callback.url" }
+
+    response = Transbank::Onepay::Transaction.create(shopping_cart: cart, options: options)
+    assert_equal response.response_code, "OK"
+    assert_equal response.description, "OK"
+    refute_nil response.qr_code_as_base64
+  ensure
+    Transbank::Onepay::Base.callback_url = original_callback_url
+  end
+
   def test_transaction_fails_when_channel_is_app_and_app_scheme_is_null
     original_app_scheme = Transbank::Onepay::Base.app_scheme
     Transbank::Onepay::Base.app_scheme = nil


### PR DESCRIPTION
Putting callback_url in the default_options hash give us the chance to pass a different callback_url (if needed) when the transaction is created.

The usecase is basically when you have a multi-account app (with multiple credentials) all the settings have to be "editable".