### PR TITLE
Add json dependency ~> 2.0 to make sure having correct json version t…

### DIFF
--- a/transbank-sdk.gemspec
+++ b/transbank-sdk.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "json", "~> 2.0"
   spec.add_development_dependency "bundler", "~> 2.1.0"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "minitest", "~> 5.0"


### PR DESCRIPTION
== Description

  A exception was raised when trying to commit a transaction with 

  ```ruby
    Transbank::Webpay::WebpayPlus::Transaction::commit(token: token)
  ```
== How to reproduce

  Add json dependency to ~> 1.8

 == Solution

  Add json dependency to ~> 2.0 to make sure having the correct json version to avoid that exception in projects that could have json 1.8 as dependency 

 