### PR TITLE
Fix call to MallTransaction#refund

### DIFF
--- a/lib/transbank/sdk/webpay/webpay_plus/mall_transaction.rb
+++ b/lib/transbank/sdk/webpay/webpay_plus/mall_transaction.rb
@@ -50,9 +50,9 @@ module Transbank
     
         def refund(token, buy_order, child_commerce_code, amount)
 
+          Transbank::Common::Validation.has_text_with_max_length(token, Transbank::Common::ApiConstants::TOKEN_LENGTH, "token")
           Transbank::Common::Validation.has_text_with_max_length(buy_order, Transbank::Common::ApiConstants::BUY_ORDER_LENGTH, "buy_order")
           Transbank::Common::Validation.has_text_with_max_length(child_commerce_code, Transbank::Common::ApiConstants::COMMERCE_CODE_LENGTH, "child_commerce_code")
-          Transbank::Common::Validation.has_text_with_max_length(child_buy_order, Transbank::Common::ApiConstants::BUY_ORDER_LENGTH, "child_buy_order")
 
           request_service = ::Transbank::Shared::RequestService.new(
             @environment, format(REFUND_ENDPOINT, token: token), @commerce_code, @api_key


### PR DESCRIPTION
It is not possible to call the refund() method of the MallTransaction
class because it is expecting a variable called child_buy_order to be
defined, yet this variable is not available anywhere (and it is not
used).

Unfortunately it seems that MallTransaction is not tested, so I cannot
add a test case to the test suite, but calling this method in a
bin/console yields the expected results in terms of API communications
after doing a refund and validating it with status().

At the same time, I am adding a validation for the token because it
seems that it is missing and it is probably a good idea given that every
other method in MallTransaction, plus methods in Transaction, do
validate the length of the token.